### PR TITLE
Added HasOptionsInterface

### DIFF
--- a/src/Task/Delete.php
+++ b/src/Task/Delete.php
@@ -10,7 +10,7 @@ use de\codenamephp\deployer\base\task\iTaskWithName;
  *
  * @psalm-api
  */
-final class Delete extends AbstractCrontabCommand implements iTaskWithName, iTaskWithDescription {
+final class Delete extends AbstractCrontabCommand implements iTaskWithName, iTaskWithDescription, HasOptionsInterface {
 
   public const NAME = 'crontab:delete';
 

--- a/src/Task/Show.php
+++ b/src/Task/Show.php
@@ -10,7 +10,7 @@ use de\codenamephp\deployer\base\task\iTaskWithName;
  *
  * @psalm-api
  */
-final class Show extends AbstractCrontabCommand implements iTaskWithName, iTaskWithDescription {
+final class Show extends AbstractCrontabCommand implements iTaskWithName, iTaskWithDescription, HasOptionsInterface {
 
   public const NAME = 'crontab:show';
 

--- a/test/Task/DeleteTest.php
+++ b/test/Task/DeleteTest.php
@@ -2,6 +2,8 @@
 
 namespace de\codenamephp\deployer\crontab\test\Task;
 
+use de\codenamephp\deployer\command\runner\iRunner;
+use de\codenamephp\deployer\crontab\Command\CrontabCommandFactoryInterface;
 use de\codenamephp\deployer\crontab\Task\Delete;
 use PHPUnit\Framework\TestCase;
 
@@ -17,5 +19,12 @@ final class DeleteTest extends TestCase {
 
   public function testGetOptions() : void {
     self::assertSame(['-r'], (new Delete())->getOptions());
+  }
+
+  public function test__invoke() : void {
+    $crontabCommandFactory = $this->createMock(CrontabCommandFactoryInterface::class);
+    $crontabCommandFactory->expects(self::once())->method('build')->with(['-r']);
+
+    (new Delete(crontabCommandFactory: $crontabCommandFactory, commandRunner: $this->createMock(iRunner::class)))->__invoke();
   }
 }

--- a/test/Task/ShowTest.php
+++ b/test/Task/ShowTest.php
@@ -2,6 +2,8 @@
 
 namespace de\codenamephp\deployer\crontab\test\Task;
 
+use de\codenamephp\deployer\command\runner\iRunner;
+use de\codenamephp\deployer\crontab\Command\CrontabCommandFactoryInterface;
 use de\codenamephp\deployer\crontab\Task\Show;
 use PHPUnit\Framework\TestCase;
 
@@ -17,5 +19,12 @@ final class ShowTest extends TestCase {
 
   public function testGetDescription() : void {
     self::assertSame('Shows the crontab', (new Show())->getDescription());
+  }
+
+  public function test__invoke() : void {
+    $crontabCommandFactory = $this->createMock(CrontabCommandFactoryInterface::class);
+    $crontabCommandFactory->expects(self::once())->method('build')->with(['-l']);
+
+    (new Show(crontabCommandFactory: $crontabCommandFactory, commandRunner: $this->createMock(iRunner::class)))->__invoke();
   }
 }


### PR DESCRIPTION
The Delete and Show tasks were missing the HasOptionsInteface so their options were never used.