### PR TITLE
Added ability to show output

### DIFF
--- a/.idea/copyright/Apache2.xml
+++ b/.idea/copyright/Apache2.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="  Copyright &amp;#36;originalComment.match(&quot;Copyright \(c\) (\d+)&quot;, 1, &quot;-&quot;, &quot;&amp;#36;today.year&quot;)&amp;#36;today.year Bastian Schwarz &lt;bastian@codename-php.de&gt;.&#10;&#10;  Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;  you may not use this file except in compliance with the License.&#10;  You may obtain a copy of the License at&#10;&#10;        http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;  Unless required by applicable law or agreed to in writing, software&#10;  distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;  See the License for the specific language governing permissions and&#10;  limitations under the License." />
+    <option name="myName" value="Apache2" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="Apache2" />
+</component>

--- a/src/Task/AbstractCrontabCommand.php
+++ b/src/Task/AbstractCrontabCommand.php
@@ -1,7 +1,24 @@
 <?php declare(strict_types=1);
+/*
+ *   Copyright 2023 Bastian Schwarz <bastian@codename-php.de>.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 
 namespace de\codenamephp\deployer\crontab\Task;
 
+use de\codenamephp\deployer\base\functions\All;
+use de\codenamephp\deployer\base\functions\iWriteln;
 use de\codenamephp\deployer\base\task\iTask;
 use de\codenamephp\deployer\command\runner\iRunner;
 use de\codenamephp\deployer\command\runner\WithDeployerFunctions;
@@ -19,7 +36,8 @@ abstract class AbstractCrontabCommand implements iTask {
   public function __construct(
     public readonly ?string $user = null,
     public readonly CrontabCommandFactoryInterface $crontabCommandFactory = new WithBinaryFromDeployer(),
-    public readonly iRunner $commandRunner = new WithDeployerFunctions()
+    public readonly iRunner $commandRunner = new WithDeployerFunctions(),
+    public readonly iWriteln $writeln = new All()
   ) {}
 
   /**
@@ -34,6 +52,7 @@ abstract class AbstractCrontabCommand implements iTask {
   }
 
   final public function __invoke() : void {
-    $this->commandRunner->run($this->crontabCommandFactory->build($this->getOptionsWithUser()));
+    $output = $this->commandRunner->run($this->crontabCommandFactory->build($this->getOptionsWithUser()));
+    !$this instanceof HasOutputInteface ?: $this->writeln->writeln(PHP_EOL . $output);
   }
 }

--- a/src/Task/HasOutputInteface.php
+++ b/src/Task/HasOutputInteface.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ *   Copyright 2023 Bastian Schwarz <bastian@codename-php.de>.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+namespace de\codenamephp\deployer\crontab\Task;
+
+/**
+ * Interface for tasks that have output that should be printed to the console. This is just a marking interface to be able to filter tasks that have output
+ */
+interface HasOutputInteface { }

--- a/src/Task/Show.php
+++ b/src/Task/Show.php
@@ -1,4 +1,19 @@
 <?php declare(strict_types=1);
+/*
+ *   Copyright 2023 Bastian Schwarz <bastian@codename-php.de>.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 
 namespace de\codenamephp\deployer\crontab\Task;
 
@@ -10,7 +25,7 @@ use de\codenamephp\deployer\base\task\iTaskWithName;
  *
  * @psalm-api
  */
-final class Show extends AbstractCrontabCommand implements iTaskWithName, iTaskWithDescription, HasOptionsInterface {
+final class Show extends AbstractCrontabCommand implements iTaskWithName, iTaskWithDescription, HasOptionsInterface, HasOutputInteface {
 
   public const NAME = 'crontab:show';
 

--- a/test/Task/ShowTest.php
+++ b/test/Task/ShowTest.php
@@ -1,7 +1,23 @@
 <?php declare(strict_types=1);
+/*
+ *   Copyright 2023 Bastian Schwarz <bastian@codename-php.de>.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 
 namespace de\codenamephp\deployer\crontab\test\Task;
 
+use de\codenamephp\deployer\base\functions\iWriteln;
 use de\codenamephp\deployer\command\runner\iRunner;
 use de\codenamephp\deployer\crontab\Command\CrontabCommandFactoryInterface;
 use de\codenamephp\deployer\crontab\Task\Show;
@@ -25,6 +41,9 @@ final class ShowTest extends TestCase {
     $crontabCommandFactory = $this->createMock(CrontabCommandFactoryInterface::class);
     $crontabCommandFactory->expects(self::once())->method('build')->with(['-l']);
 
-    (new Show(crontabCommandFactory: $crontabCommandFactory, commandRunner: $this->createMock(iRunner::class)))->__invoke();
+    $writeln = $this->createMock(iWriteln::class);
+    $writeln->expects(self::once())->method('writeln');
+
+    (new Show(crontabCommandFactory: $crontabCommandFactory, commandRunner: $this->createMock(iRunner::class), writeln: $writeln))->__invoke();
   }
 }


### PR DESCRIPTION
Tasks can now write their output to the command line by adding the HasOutputInterface marking interface. Nothing has to be implemented as the Abstract Task detects the interface and write the output to the console.